### PR TITLE
spelling: occurred

### DIFF
--- a/WindowsEventIDMapping.json
+++ b/WindowsEventIDMapping.json
@@ -1065,7 +1065,7 @@
                     "level": "Information",
                     "channel": "Microsoft-Windows-WMI-Activity/Operational",
                     "provider": "Microsoft-Windows-WMI-Activity",
-                    "notes": "A WMI query error has occured"
+                    "notes": "A WMI query error has occurred"
                 }
             },
             "Temporary WMI event subscription created": {

--- a/subscriptions/subscription.xml
+++ b/subscriptions/subscription.xml
@@ -208,7 +208,7 @@
     <Select Path="Microsoft-Windows-Win32k/Operational">*[System[Provider[@Name="Microsoft-Windows-Win32k"] and (EventID=260)]]</Select>
   </Query>
   <!--5857: A WMI provider was loaded-->
-  <!--5858: A WMI query error has occured-->
+  <!--5858: A WMI query error has occurred-->
   <!--5860: A temporary WMI event subscription has been created-->
   <!--5861: A permanent WMI event subscription has been created-->
   <Query Id="23" Path="Microsoft-Windows-WMI-Activity/Operational">


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/logging-essentials/commit/ceca90c5847836e2749ec5ea8bd35217b140abe3#commitcomment-49961504

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/logging-essentials/commit/9d56fabf53f22cdf7132bccc8d26c879d778f934

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.